### PR TITLE
`remove_connections_request` signal in DialogGraphNode

### DIFF
--- a/net.bobbo.dialog-graph/dialog_graph_node.gd
+++ b/net.bobbo.dialog-graph/dialog_graph_node.gd
@@ -8,6 +8,10 @@ class_name DialogGraphNode
 
 ## Emitted when this node's data has been changed in some way
 signal data_updated(data: GraphNodeData)
+## Emitted when this node is requesting that all connections be removed from a
+## specific slot. `side` is which side of the slot to remove from (-1 for left,
+## 1 for right). `slot` is the actual slot index to remove connections from.
+signal remove_connections_request(side: int, slot: int)
 
 #
 #	Public Variables

--- a/net.bobbo.dialog-graph/nodes/choice_prompt/choice_prompt_node.gd
+++ b/net.bobbo.dialog-graph/nodes/choice_prompt/choice_prompt_node.gd
@@ -66,6 +66,10 @@ func _remove_last_option() -> void:
 	_casted_data.options.pop_back()
 	data_updated.emit(_casted_data)
 	
+	# Request that any connections on the port we just removed be removed as
+	# well, so that there's no invalid connections.
+	remove_connections_request.emit(1, _casted_data.options.size())
+	
 func _new_option_control() -> ChoicePromptOptionContainer:
 	var new_option = choice_option_scene.instantiate()
 	add_child(new_option)


### PR DESCRIPTION
This PR implements the `remove_connections_request` signal to DialogGraphNode. This signal allows dialog graph nodes to request that connections in the graph be removed on specific connection slots of node. This is necessary for things like the ChoicePrompt node, which will need to request that slots are disconnected when removed.