### PR TITLE
`CharacterDefinition` tracks body and head nodes

### DIFF
--- a/net.bobbo.character/README.md
+++ b/net.bobbo.character/README.md
@@ -22,8 +22,6 @@ This plugin is made for Godot 4.1. The following plugins must be installed:
 
 CharacterDefinitions allow you to assign a character a position, or track a character to a node's position. Having this functionality be exposed via a resource is useful because it allows one to reference a potentially in-game character *outside* the context of the scene that they're in. Examples of why this is useful can be seen in dialog: it's nice to reference a character by referencing their CharacterDefinition, and then have some other node or system supply the actual physical position to that character on it's own.
 
-You can set the position of a character by calling either `set_position()` or `set_tracked_node()` on a CharacterDefinition. If you set a character's tracked node, then whenever you call `get_position()` on that character, it will return the position of the tracked node. This is helpful if you just want a character's position to be defined by some object in-game.
-
 ### Phyiscal vs Non-Physical Characters
 
 A character is considered physical if there is something currently representing them in the game world. In another way, a character is physical if they have an active position assigned to them. When `set_position()` or `set_tracked_node()` is called, a character is automatically set as physical.  

--- a/net.bobbo.character/character_definition.gd
+++ b/net.bobbo.character/character_definition.gd
@@ -28,6 +28,33 @@ var data: Dictionary:
 			_data_raw = default_data.duplicate(true)
 		return _data_raw
 
+## The body node of this character in-game, if there is one. Typically
+## the root of the character. Should be either Node3D or Node2D.
+var body_node: Variant:
+	get: return body_node
+	set(value):
+		if not (value == null or value is Node2D or value is Node3D):
+			push_warning("Tried to assign a value to `body_node` that isn't null, Node2D, or Node3D (%s)" % value)
+			body_node = null
+		else:
+			body_node = value
+
+## The head / aim direction node of this character in game, if there is
+## one. Typically the head of the character, or where the character's camera
+## would be. Should be either Node3D or Node2D.
+var head_node: Variant:
+	get: return head_node
+	set(value):
+		if not (value == null or value is Node2D or value is Node3D):
+			push_warning("Tried to assign a value to `head_node` that isn't null, Node2D, or Node3D (%s)" % value)
+			head_node = null
+		else:
+			head_node = value
+
+## Is this character currently located in the game world?
+var is_physical: bool:
+	get: return body_node != null or head_node != null
+
 #
 #	Private Variables
 #
@@ -35,46 +62,3 @@ var data: Dictionary:
 ## Raw untyped Dictionary (NO TYPE hint so it can be null) backing
 ## the `data` property.
 var _data_raw = null
-
-## Is this character currenty located in-game?
-var _is_physical: bool = false
-
-## If not null, this node's position is the character's physical position
-var _tracked_node = null
-
-## If _tracked_node is null, this is the character's physical position
-var _position = Vector3.ZERO
-
-#
-#	Functions
-#
-
-## Is this character currently located in the game world?
-func is_physical() -> bool:
-	return _is_physical
-
-## Get the node that this character is currently tracked to. Expected to have
-## a `.position` property.
-func get_tracked_node():
-	return _tracked_node
-	
-## Assign a node for this character to track to. This will override the return
-## result of `.get_position()` to be the global position of this node.
-func set_tracked_node(node):
-	_tracked_node = node
-	if node:
-		_is_physical = true
-
-## The position of this character in the game world. Uses the tracked node if
-## set, otherwise just uses an internal position variable.
-func get_position():
-	if _tracked_node:
-		return _tracked_node.global_position
-	
-	return _position
-	
-## Set the internal position of this character, which is used if there's no
-## tracked node set.
-func set_position(pos):
-	_position = pos
-	_is_physical = true

--- a/net.bobbo.item/item_script_base.gd
+++ b/net.bobbo.item/item_script_base.gd
@@ -68,8 +68,8 @@ var character: CharacterDefinition:
 ## scenario?
 var player3d: PlayerController:
     get:
-        if character and character.get_tracked_node() is PlayerController:
-            return character.get_tracked_node()
+        if character and character.body_node is PlayerController:
+            return character.body_node
         return null
 
 #

--- a/net.bobbo.item/item_script_base.gd
+++ b/net.bobbo.item/item_script_base.gd
@@ -63,15 +63,6 @@ var character: CharacterDefinition:
         if interactor: return interactor.character
         return null
 
-## The `PlayerController` that is using this item, if there is one.
-## TODO - I don't know if I like this. How would an NPC use the same item code in this
-## scenario?
-var player3d: PlayerController:
-    get:
-        if character and character.body_node is PlayerController:
-            return character.body_node
-        return null
-
 #
 #   Public Functions
 #

--- a/net.bobbo.player-controller/player_controller.gd
+++ b/net.bobbo.player-controller/player_controller.gd
@@ -44,7 +44,8 @@ func _ready():
 		character_definition.name = "Player"
 
 	# Make sure that the character def knows where our player character is
-	character_definition.set_tracked_node(self)
+	character_definition.body_node = self
+	character_definition.head_node = camera
 
 	# Setup the item interactor
 	item_interactor.inventory = inventory

--- a/net.bobbo.text-window/projection_character_focus.gd
+++ b/net.bobbo.text-window/projection_character_focus.gd
@@ -12,14 +12,14 @@ func _process(delta):
 	if !current_character:
 		return
 		
-	_projection.set_focus_position(current_character.get_position())
+	_projection.set_focus_position(current_character.body_node.position)
 
 #
 #	Private Functions
 #
 
 func _set_target_character(character: CharacterDefinition) -> void:
-	if character and character.is_physical():
+	if character and character.is_physical:
 		current_character = character
 	else:
 		current_character = null


### PR DESCRIPTION
Refactors `CharacterDefinition` to track body and head nodes instead of a generic position. I've removed the set_position concept from character defs - it doesn't seem relevant or necessary. Now a def can have a body node and head node assigned. This is useful for item scripting to be decoupled from the 3D player controller, as it can now just use the `CharacterDefinition`'s tracked nodes.