### PR TITLE
`VirtualCamera`: Self-Group Management

### DIFF
--- a/net.bobbo.virtual-camera/virtual_camera_2d.gd
+++ b/net.bobbo.virtual-camera/virtual_camera_2d.gd
@@ -61,8 +61,16 @@ func _init() -> void:
 func _enter_tree() -> void:
 	add_to_group(GROUP_NAME)
 
+	# Manually trigger a vis change so that we add ourself to the tree's
+	# visible group for this vcam type.
+	_on_self_visibility_changed()
+
 
 func _exit_tree() -> void:
+	# Remove us from the visible group if this vcam is currently in it
+	if visible:
+		remove_from_group(VISIBLE_GROUP_NAME)
+
 	remove_from_group(GROUP_NAME)
 
 

--- a/net.bobbo.virtual-camera/virtual_camera_2d.gd
+++ b/net.bobbo.virtual-camera/virtual_camera_2d.gd
@@ -1,4 +1,80 @@
 class_name VirtualCamera2D
 extends Node2D
 
-## TODO
+#
+#   Constants
+#
+
+## The name of the group that ALL `VirtualCamera2D`s are stored in.
+const GROUP_NAME: String = "vcams_2d_all"
+
+## The name of the group that all VISIBLE `VirtualCamera2D`s are stored
+## in. VCams will be added and removed to this group upon change in
+## the `visible` property.
+const VISIBLE_GROUP_NAME: String = "vcams_2d_visible"
+
+#
+#	Static Functions
+#
+
+
+## Get all of the 2D VCams that exist in the given scene.
+## Args:
+##	`scene_tree`: OPTIONAL. The SceneTree to get the 2D VCams from.
+## Returns:
+##	`Array[VirtualCamera2D]` a list of 2D VCams that exist in the given
+##		scene.
+static func get_all(scene_tree: SceneTree) -> Array[VirtualCamera2D]:
+	# Cast the generic array from the scene tree into something typed.
+	var found_vcams: Array[VirtualCamera2D] = []
+	found_vcams.assign(scene_tree.get_nodes_in_group(GROUP_NAME))
+	return found_vcams
+
+
+## Get all of the *VISIBLE* 2D VCams that exist in the given scene.
+## These are VCams that have their 2D `visible` property set to true.
+## Args:
+##	`scene_tree`: OPTIONAL. The SceneTree to get the 2D VCams from.
+## Returns:
+##	`Array[VirtualCamera2D]` a list of visible 2D VCams that exist in
+##		the given scene.
+static func get_visible(scene_tree: SceneTree) -> Array[VirtualCamera2D]:
+	# Cast the generic array from the scene tree into something typed.
+	var found_vcams: Array[VirtualCamera2D] = []
+	found_vcams.assign(scene_tree.get_nodes_in_group(VISIBLE_GROUP_NAME))
+	return found_vcams
+
+
+#
+#   Godot Functions
+#
+
+
+func _init() -> void:
+	# Make sure we react to visibility changes
+	visibility_changed.connect(_on_self_visibility_changed.bind())
+
+	# ...and call the callback right away, so we start with a good state
+	_on_self_visibility_changed()
+
+
+func _enter_tree() -> void:
+	add_to_group(GROUP_NAME)
+
+
+func _exit_tree() -> void:
+	remove_from_group(GROUP_NAME)
+
+
+#
+#   Signals
+#
+
+
+## Whenever this node's visibility changes, handle adding it or removing
+## it to / from the visible group for this kind of VCam.
+func _on_self_visibility_changed() -> void:
+	if visible:
+		add_to_group(VISIBLE_GROUP_NAME)
+	else:
+		remove_from_group(VISIBLE_GROUP_NAME)

--- a/net.bobbo.virtual-camera/virtual_camera_3d.gd
+++ b/net.bobbo.virtual-camera/virtual_camera_3d.gd
@@ -31,6 +31,20 @@ static func get_all(scene_tree: SceneTree) -> Array[VirtualCamera3D]:
 	return found_vcams
 
 
+## Get all of the *VISIBLE* 3D VCams that exist in the given scene.
+## These are VCams that have their 3D `visible` property set to true.
+## Args:
+##	`scene_tree`: OPTIONAL. The SceneTree to get the 3D VCams from.
+## Returns:
+##	`Array[VirtualCamera3D]` a list of visible 3D VCams that exist in
+##		the given scene.
+static func get_visible(scene_tree: SceneTree) -> Array[VirtualCamera3D]:
+	# Cast the generic array from the scene tree into something typed.
+	var found_vcams: Array[VirtualCamera3D] = []
+	found_vcams.assign(scene_tree.get_nodes_in_group(VISIBLE_GROUP_NAME))
+	return found_vcams
+
+
 #
 #   Godot Functions
 #
@@ -42,10 +56,6 @@ func _init() -> void:
 
 	# ...and call the callback right away, so we start with a good state
 	_on_self_visibility_changed()
-
-
-func _ready():
-	print(get_all(get_tree()))
 
 
 func _enter_tree() -> void:
@@ -61,6 +71,8 @@ func _exit_tree() -> void:
 #
 
 
+## Whenever this node's visibility changes, handle adding it or removing
+## it to / from the visible group for this kind of VCam.
 func _on_self_visibility_changed() -> void:
 	if visible:
 		add_to_group(VISIBLE_GROUP_NAME)

--- a/net.bobbo.virtual-camera/virtual_camera_3d.gd
+++ b/net.bobbo.virtual-camera/virtual_camera_3d.gd
@@ -14,6 +14,24 @@ const GROUP_NAME: String = "vcams_3d_all"
 const VISIBLE_GROUP_NAME: String = "vcams_3d_visible"
 
 #
+#	Static Functions
+#
+
+
+## Get all of the 3D VCams that exist in the given scene.
+## Args:
+##	`scene_tree`: OPTIONAL. The SceneTree to get the 3D VCams from.
+## Returns:
+##	`Array[VirtualCamera3D]` a list of 3D VCams that exist in the given
+##		scene.
+static func get_all(scene_tree: SceneTree) -> Array[VirtualCamera3D]:
+	# Cast the generic array from the scene tree into something typed.
+	var found_vcams: Array[VirtualCamera3D] = []
+	found_vcams.assign(scene_tree.get_nodes_in_group(GROUP_NAME))
+	return found_vcams
+
+
+#
 #   Godot Functions
 #
 
@@ -24,6 +42,10 @@ func _init() -> void:
 
 	# ...and call the callback right away, so we start with a good state
 	_on_self_visibility_changed()
+
+
+func _ready():
+	print(get_all(get_tree()))
 
 
 func _enter_tree() -> void:

--- a/net.bobbo.virtual-camera/virtual_camera_3d.gd
+++ b/net.bobbo.virtual-camera/virtual_camera_3d.gd
@@ -13,4 +13,28 @@ const GROUP_NAME: String = "vcams_3d_all"
 ## the `visible` property.
 const VISIBLE_GROUP_NAME: String = "vcams_3d_visible"
 
-## TODO
+#
+#   Godot Functions
+#
+
+
+func _init() -> void:
+	# Make sure we react to visibility changes
+	visibility_changed.connect(_on_self_visibility_changed.bind())
+
+
+func _enter_tree() -> void:
+	add_to_group(GROUP_NAME)
+
+
+func _exit_tree() -> void:
+	remove_from_group(GROUP_NAME)
+
+
+#
+#   Signals
+#
+
+
+func _on_self_visibility_changed() -> void:
+	return

--- a/net.bobbo.virtual-camera/virtual_camera_3d.gd
+++ b/net.bobbo.virtual-camera/virtual_camera_3d.gd
@@ -1,4 +1,16 @@
 class_name VirtualCamera3D
 extends Node3D
 
+#
+#   Constants
+#
+
+## The name of the group that ALL `VirtualCamera3D`s are stored in.
+const GROUP_NAME: String = "vcams_3d_all"
+
+## The name of the group that all VISIBLE `VirtualCamera3D`s are stored
+## in. VCams will be added and removed to this group upon change in
+## the `visible` property.
+const VISIBLE_GROUP_NAME: String = "vcams_3d_visible"
+
 ## TODO

--- a/net.bobbo.virtual-camera/virtual_camera_3d.gd
+++ b/net.bobbo.virtual-camera/virtual_camera_3d.gd
@@ -22,6 +22,9 @@ func _init() -> void:
 	# Make sure we react to visibility changes
 	visibility_changed.connect(_on_self_visibility_changed.bind())
 
+	# ...and call the callback right away, so we start with a good state
+	_on_self_visibility_changed()
+
 
 func _enter_tree() -> void:
 	add_to_group(GROUP_NAME)
@@ -37,4 +40,7 @@ func _exit_tree() -> void:
 
 
 func _on_self_visibility_changed() -> void:
-	return
+	if visible:
+		add_to_group(VISIBLE_GROUP_NAME)
+	else:
+		remove_from_group(VISIBLE_GROUP_NAME)

--- a/net.bobbo.virtual-camera/virtual_camera_3d.gd
+++ b/net.bobbo.virtual-camera/virtual_camera_3d.gd
@@ -54,15 +54,20 @@ func _init() -> void:
 	# Make sure we react to visibility changes
 	visibility_changed.connect(_on_self_visibility_changed.bind())
 
-	# ...and call the callback right away, so we start with a good state
-	_on_self_visibility_changed()
-
 
 func _enter_tree() -> void:
 	add_to_group(GROUP_NAME)
 
+	# Manually trigger a vis change so that we add ourself to the tree's
+	# visible group for this vcam type.
+	_on_self_visibility_changed()
+
 
 func _exit_tree() -> void:
+	# Remove us from the visible group if this vcam is currently in it
+	if visible:
+		remove_from_group(VISIBLE_GROUP_NAME)
+
 	remove_from_group(GROUP_NAME)
 
 


### PR DESCRIPTION
`VirtualCamera2D` and `VirtualCamera3D` nodes now add themselves to groups. On tree entry / exit, they're added/removed to a group to make finding vcams easier. On visible / hidden they're added / removed to another group to make finding ACTIVE vcams easier.