### PR TITLE
MouseLook Character Script uses EntityInput

### DIFF
--- a/net.bobbo.character.players/first_person_player.tscn
+++ b/net.bobbo.character.players/first_person_player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://b4nwduau6uxjr"]
+[gd_scene load_steps=22 format=3 uid="uid://b4nwduau6uxjr"]
 
 [ext_resource type="Script" path="res://addons/netengine5/net.bobbo.character/character_agent_3d.gd" id="1_f5l1k"]
 [ext_resource type="PackedScene" uid="uid://cki8segkyvq7t" path="res://addons/netengine5/net.bobbo.character/agent_scripts/gravity_default.tscn" id="2_atrpy"]
@@ -14,9 +14,10 @@
 [ext_resource type="PackedScene" uid="uid://bfwsj3q80wj8q" path="res://addons/netengine5/net.bobbo.character/agent_scripts/item_selector_default.tscn" id="10_yrp2c"]
 [ext_resource type="Script" path="res://addons/netengine5/net.bobbo.item/item_inventory.gd" id="11_bf8wo"]
 [ext_resource type="PackedScene" uid="uid://40a8nwm87ybx" path="res://addons/netengine5/net.bobbo.character/agent_scripts/item_user_default.tscn" id="11_weqc3"]
-[ext_resource type="PackedScene" path="res://addons/netengine5/net.bobbo.character/agent_scripts/mouse_look.tscn" id="12_m6trc"]
+[ext_resource type="PackedScene" uid="uid://x62vcgjprloq" path="res://addons/netengine5/net.bobbo.character/agent_scripts/mouse_look.tscn" id="12_m6trc"]
 [ext_resource type="Script" path="res://addons/netengine5/net.bobbo.virtual-camera/virtual_camera_3d.gd" id="14_inmo7"]
 [ext_resource type="Script" path="res://addons/netengine5/net.bobbo.entity-input/player_input.gd" id="17_1081f"]
+[ext_resource type="Script" path="res://addons/netengine5/net.bobbo.entity-input/player_input_mouse.gd" id="18_gyc1i"]
 [ext_resource type="Script" path="res://addons/netengine5/net.bobbo.entity-input/player_input_action.gd" id="18_k6u20"]
 [ext_resource type="Script" path="res://addons/netengine5/net.bobbo.entity-input/player_input_analog.gd" id="19_20juw"]
 
@@ -54,6 +55,9 @@ script = ExtResource("11_bf8wo")
 
 [node name="PlayerInput" type="Node" parent="."]
 script = ExtResource("17_1081f")
+
+[node name="player_look" type="Node" parent="PlayerInput"]
+script = ExtResource("18_gyc1i")
 
 [node name="player_move" type="Node" parent="PlayerInput"]
 

--- a/net.bobbo.character/agent_scripts/air_movement.gd
+++ b/net.bobbo.character/agent_scripts/air_movement.gd
@@ -49,7 +49,7 @@ func character_agent_physics_process(delta: float) -> void:
 
 
 func _get_rotated_movement_dir() -> Vector3:
-	var movement_input = agent_3d.input.read_axis_2d(_move_axis)
+	var movement_input = agent_3d.input.read_axis_2d(_move_axis).normalized()
 
 	# Rotate the input to match facing dir
 	return Vector3(movement_input.x, 0, movement_input.y).rotated(

--- a/net.bobbo.character/agent_scripts/air_movement.gd
+++ b/net.bobbo.character/agent_scripts/air_movement.gd
@@ -13,18 +13,14 @@ extends CharacterAgentScript
 #
 
 ## An input wrapper to make getting the movement axis easier
-var _move_axis: InputAxis2d = null
+var _move_axis: InputAxis2d = InputAxis2d.new(
+	InputAxis1d.new("player_move_left", "player_move_right"),
+	InputAxis1d.new("player_move_forward", "player_move_back")
+)
 
 #
 #	Functions
 #
-
-
-func character_agent_ready() -> void:
-	_move_axis = InputAxis2d.new(
-		InputAxis1d.new("player_move_left", "player_move_right"),
-		InputAxis1d.new("player_move_forward", "player_move_back")
-	)
 
 
 func character_agent_physics_process(delta: float) -> void:

--- a/net.bobbo.character/agent_scripts/ground_movement.gd
+++ b/net.bobbo.character/agent_scripts/ground_movement.gd
@@ -23,7 +23,10 @@ const CROUCH_ACTION: String = "player_crouch"
 #
 
 ## An input wrapper to make getting the movement axis easier
-var _move_axis: InputAxis2d = null
+var _move_axis: InputAxis2d = InputAxis2d.new(
+	InputAxis1d.new("player_move_left", "player_move_right"),
+	InputAxis1d.new("player_move_forward", "player_move_back")
+)
 
 ## Is the entity trying to crouch right now?
 var _should_crouch: bool = false
@@ -34,13 +37,6 @@ var _should_run: bool = false
 #
 #	Functions
 #
-
-
-func character_agent_ready() -> void:
-	_move_axis = InputAxis2d.new(
-		InputAxis1d.new("player_move_left", "player_move_right"),
-		InputAxis1d.new("player_move_forward", "player_move_back")
-	)
 
 
 func character_agent_physics_process(delta: float) -> void:

--- a/net.bobbo.character/agent_scripts/ground_movement.gd
+++ b/net.bobbo.character/agent_scripts/ground_movement.gd
@@ -63,7 +63,7 @@ func character_agent_physics_process(delta: float) -> void:
 
 
 func _get_rotated_movement_dir() -> Vector3:
-	var movement_input = agent_3d.input.read_axis_2d(_move_axis)
+	var movement_input = agent_3d.input.read_axis_2d(_move_axis).normalized()
 
 	# Rotate the input to match facing dir
 	return Vector3(movement_input.x, 0, movement_input.y).rotated(

--- a/net.bobbo.character/agent_scripts/mouse_look.gd
+++ b/net.bobbo.character/agent_scripts/mouse_look.gd
@@ -2,11 +2,17 @@
 extends CharacterAgentScript
 
 #
+#	Constants
+#
+
+const DEGRESS_PER_UNIT: float = 0.001
+
+#
 #	Exports
 #
 
-@export var sensitivity_x: float = 0.25
-@export var sensitivity_y: float = 0.25
+@export var sensitivity_x: float = 250
+@export var sensitivity_y: float = 250
 
 #
 #   Private Variables
@@ -27,6 +33,7 @@ func character_agent_process(_delta: float) -> void:
 	var look_movement := (
 		agent_3d.input.read_axis_2d(_look_axis)
 		* Vector2(sensitivity_x, sensitivity_y)
+		* DEGRESS_PER_UNIT
 	)
 
 	# Calculate the rotation amount then apply

--- a/net.bobbo.character/agent_scripts/mouse_look.gd
+++ b/net.bobbo.character/agent_scripts/mouse_look.gd
@@ -2,17 +2,39 @@
 extends CharacterAgentScript
 
 #
+#	Exports
+#
+
+@export var sensitivity_x: float = 0.25
+@export var sensitivity_y: float = 0.25
+
+#
 #   Private Variables
 #
 
-@onready var _mouse_look: MouseLook3D = $MouseLook3D
+## An input wrapper to make getting mouse movement easier
+var _look_axis: InputAxis2d = InputAxis2d.new(
+	InputAxis1d.new("player_look_left", "player_look_right"),
+	InputAxis1d.new("player_look_down", "player_look_up")
+)
 
 #
 #   Agent Functions
 #
 
 
-func character_agent_ready() -> void:
-	# Put the mouselook under our head node
-	_mouse_look.reparent(agent.head_node, false)
-	_mouse_look.model_pivot = agent_3d.playermodel_pivot
+func character_agent_process(_delta: float) -> void:
+	var look_movement := (
+		agent_3d.input.read_axis_2d(_look_axis)
+		* Vector2(sensitivity_x, sensitivity_y)
+	)
+
+	# Calculate the rotation amount then apply
+	var new_rotation: Vector3 = agent_3d.head_node.rotation_degrees
+	new_rotation.x = clampf(new_rotation.x - look_movement.y, -90.0, 90.0)
+	new_rotation.y -= look_movement.x
+	agent_3d.head_node.rotation_degrees = new_rotation
+	agent_3d.head_node.orthonormalize()
+
+	# Make the playermodel rotate with the head
+	agent_3d.playermodel_pivot.rotation.y = agent.head_node.rotation.y

--- a/net.bobbo.character/agent_scripts/mouse_look.tscn
+++ b/net.bobbo.character/agent_scripts/mouse_look.tscn
@@ -1,12 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://cs7520w6fdog0"]
+[gd_scene load_steps=2 format=3 uid="uid://x62vcgjprloq"]
 
 [ext_resource type="Script" path="res://addons/netengine5/net.bobbo.character/agent_scripts/mouse_look.gd" id="1_bqoj8"]
-[ext_resource type="Script" path="res://addons/netengine5/net.bobbo.mouse-look-3d/mouse_look_3d.gd" id="2_w8rr6"]
 
 [node name="MouseLook" type="Node"]
 script = ExtResource("1_bqoj8")
-
-[node name="MouseLook3D" type="Node" parent="."]
-script = ExtResource("2_w8rr6")
-sensitivity_x = 0.25
-sensitivity_y = 0.25

--- a/net.bobbo.entity-input/entity_input.gd
+++ b/net.bobbo.entity-input/entity_input.gd
@@ -77,8 +77,8 @@ func is_action_just_released(action_name: String) -> bool:
 ## Args:
 ##	`action_name`: The name of the analog input to read.
 ## Returns:
-##	A value between 0 and 1. If the action can't be found, this will always be
-##	0.
+##	A value between 0 and Infinity. If the action can't be found, this
+## will always be 0.
 func get_analog(action_name: String) -> float:
 	return _analog_inputs.get(action_name, 0)
 
@@ -87,7 +87,7 @@ func get_analog(action_name: String) -> float:
 ## Args:
 ##	`axis`: The definition of the axis to read
 ## Returns:
-##  A value from -1 to 1, inclusive.
+##  A value from -Infinity to Infinity, inclusive.
 func read_axis_1d(axis: InputAxis1d) -> float:
 	return (
 		get_analog(axis.positive_action_name)
@@ -99,9 +99,9 @@ func read_axis_1d(axis: InputAxis1d) -> float:
 ## Args:
 ##	`axis`: The definition of the axis to read
 ## Returns:
-##  A normalized Vector2.
+##  A Vector2.
 func read_axis_2d(axis: InputAxis2d) -> Vector2:
-	return Vector2(read_axis_1d(axis.x), read_axis_1d(axis.y)).normalized()
+	return Vector2(read_axis_1d(axis.x), read_axis_1d(axis.y))
 
 
 #

--- a/net.bobbo.entity-input/entity_input.gd
+++ b/net.bobbo.entity-input/entity_input.gd
@@ -80,7 +80,7 @@ func is_action_just_released(action_name: String) -> bool:
 ##	A value between 0 and Infinity. If the action can't be found, this
 ## will always be 0.
 func get_analog(action_name: String) -> float:
-	return _analog_inputs.get(action_name, 0)
+	return _analog_inputs.get(action_name, 0.0)
 
 
 ## Reads the value of some 1D axis.

--- a/net.bobbo.entity-input/player_input.gd
+++ b/net.bobbo.entity-input/player_input.gd
@@ -11,6 +11,9 @@ var _input_actions: Array[PlayerInputAction] = []
 ## All known analog inputs underneath us
 var _input_analog: Array[PlayerInputAnalog] = []
 
+## All known mouse inputs underneath us
+var _input_mouse: Array[PlayerInputMouse] = []
+
 #
 #	Godot Functions
 #
@@ -18,7 +21,7 @@ var _input_analog: Array[PlayerInputAnalog] = []
 
 func _ready():
 	# Get all of our input actions
-	_find_all_inputs(self, _input_actions, _input_analog)
+	_find_all_inputs(self, _input_actions, _input_analog, _input_mouse)
 
 
 #
@@ -38,7 +41,25 @@ func gather_inputs(tick: EntityInput.TickType) -> void:
 			_register_input(input.name, state)
 
 	for analog in _input_analog:
-		_register_analog_input(analog.name, analog.get_analog_strength())
+		_register_analog_input(analog.name, analog.get_analog_strength(tick))
+
+	for mouse in _input_mouse:
+		var value := mouse.read_accumulated(tick)
+
+		if value.y > 0:
+			if mouse.up_action_name:
+				_register_analog_input(mouse.up_action_name, value.y)
+		else:
+			if mouse.down_action_name:
+				_register_analog_input(mouse.down_action_name, -value.y)
+
+		if value.x > 0:
+			if mouse.right_action_name:
+				_register_analog_input(mouse.right_action_name, value.x)
+		else:
+			if mouse.left_action_name:
+				_register_analog_input(mouse.left_action_name, -value.x)
+		mouse.clear_accumulated(tick)
 
 
 #
@@ -50,11 +71,14 @@ func _find_all_inputs(
 	starting_node: Node,
 	found_actions: Array[PlayerInputAction],
 	found_analog: Array[PlayerInputAnalog],
+	found_mouse: Array[PlayerInputMouse],
 ) -> void:
 	if starting_node is PlayerInputAction:
 		found_actions.append(starting_node)
 	if starting_node is PlayerInputAnalog:
 		found_analog.append(starting_node)
+	if starting_node is PlayerInputMouse:
+		found_mouse.append(starting_node)
 
 	for child in starting_node.get_children():
-		_find_all_inputs(child, found_actions, found_analog)
+		_find_all_inputs(child, found_actions, found_analog, found_mouse)

--- a/net.bobbo.entity-input/player_input_analog.gd
+++ b/net.bobbo.entity-input/player_input_analog.gd
@@ -11,13 +11,12 @@ extends PlayerInputAction
 #   Public Functions
 #
 
+
 ## Get the analog strength for this input.
 ## Returns:
 ##	A value between 0 and 1, inclusive.
-func get_analog_strength() -> float:
+func get_analog_strength(_tick_type: EntityInput.TickType) -> float:
 	if not InputMap.has_action(name):
 		return 0
 
 	return Input.get_action_strength(name)
-
-

--- a/net.bobbo.entity-input/player_input_mouse.gd
+++ b/net.bobbo.entity-input/player_input_mouse.gd
@@ -1,0 +1,83 @@
+## A node representation of some configurable mouse movement action.
+## Making this node based means we can allow a designer in Godot to
+## define what Input Actions should be listened for IN EDITOR, rather
+## than modifying code.
+## The name of this node should be the name of the Input Action to use.
+##
+## Thanks a ton to https://yosoyfreeman.github.io/ for the amazing insights
+## on attaining good mouselook in Godot!
+@tool
+class_name PlayerInputMouse
+extends Node
+
+#
+#	Exports
+#
+
+## The name of the analog action to use when looking up
+@export var up_action_name: String = "player_look_up"
+
+## The name of the analog action to use when looking down
+@export var down_action_name: String = "player_look_down"
+
+## The name of the analog action to use when looking left
+@export var left_action_name: String = "player_look_left"
+
+## The name of the analog action to use when looking right
+@export var right_action_name: String = "player_look_right"
+
+## Should we ignore mouse events if the mouse is not captured by the window?
+@export var ignore_when_uncaptured := true
+
+#
+#	Private Variables
+#
+
+var _accumulated_process_input: Vector2 = Vector2.ZERO
+var _accumulated_physics_input: Vector2 = Vector2.ZERO
+
+#
+#	Godot Functions
+#
+
+
+func _input(event):
+	# If the mouse isn't captured, ignore this event
+	if (
+		Input.mouse_mode != Input.MOUSE_MODE_CAPTURED
+		and ignore_when_uncaptured
+	):
+		return
+
+	# If the mouse moved, store this movement to process later
+	if event is InputEventMouseMotion:
+		# Get the viewport and use that to scale the input correctly
+		var transformed_relative = (
+			event.xformed_by(get_tree().root.get_final_transform()).relative
+		)
+
+		_accumulated_process_input += transformed_relative
+		_accumulated_physics_input += transformed_relative
+
+
+#
+#   Public Functions
+#
+
+
+## Read the accumulated mouse movement values for a specific tick type
+func read_accumulated(tick_type: EntityInput.TickType) -> Vector2:
+	if tick_type == EntityInput.TickType.PROCESS:
+		return _accumulated_process_input
+	if tick_type == EntityInput.TickType.PROCESS_PHYSICS:
+		return _accumulated_physics_input
+
+	return Vector2.ZERO
+
+
+## Clear any accumulated mouse movement values from a specific tick type
+func clear_accumulated(tick_type: EntityInput.TickType) -> void:
+	if tick_type == EntityInput.TickType.PROCESS:
+		_accumulated_process_input = Vector2.ZERO
+	if tick_type == EntityInput.TickType.PROCESS_PHYSICS:
+		_accumulated_physics_input = Vector2.ZERO

--- a/net.bobbo.entity-input/plugin.gd
+++ b/net.bobbo.entity-input/plugin.gd
@@ -28,6 +28,12 @@ func _enter_tree():
 		preload("icons/player_input_analog.png")
 	)
 	add_custom_type(
+		"PlayerInputMouse",
+		"Node",
+		preload("player_input_mouse.gd"),
+		preload("icons/player_input.png")
+	)
+	add_custom_type(
 		"SimulatedInput",
 		"Node",
 		preload("simulated_input.gd"),
@@ -37,6 +43,7 @@ func _enter_tree():
 
 func _exit_tree():
 	remove_custom_type("SimulatedInput")
+	remove_custom_type("PlayerInputMouse")
 	remove_custom_type("PlayerInputAnalog")
 	remove_custom_type("PlayerInputAction")
 	remove_custom_type("PlayerInput")

--- a/net.bobbo.entity-input/simulated_input.gd
+++ b/net.bobbo.entity-input/simulated_input.gd
@@ -124,8 +124,8 @@ func simulate_analog(action_name: String, strength: float) -> void:
 ## Simulate some 1d analog axis.
 ## Args:
 ##	`axis`: The axis to simulate an input for.
-##	`value`: The value to assign to the axis. Should be between -1 and 1
-##		inclusive.
+##	`value`: The value to assign to the axis. Should be between -Infinity and
+##		Infinity.
 func simulate_axis_1d(axis: InputAxis1d, value: float) -> void:
 	if value > 0:
 		simulate_analog(axis.positive_action_name, value)
@@ -138,7 +138,7 @@ func simulate_axis_1d(axis: InputAxis1d, value: float) -> void:
 ## Simulate some 2d analog axis.
 ## Args:
 ##	`axis`: The axis to simulate and input for.
-##	`value`: The ablue to assign to the axis. It should be normalized.
+##	`value`: The ablue to assign to the axis.
 func simulate_axis_2d(axis: InputAxis2d, value: Vector2) -> void:
 	simulate_axis_1d(axis.x, value.x)
 	simulate_axis_1d(axis.y, value.y)


### PR DESCRIPTION
Refactors the MouseLook CharacterScript to use it's CharacterAgent's EntityInput for mouse input. To do this, the spec for analog inputs have been revised to NOT be between 0 and 1, or -1 and 1. They're now uncapped to account for rapid mouse movements.

Because this takes advantage of EntityInput's analog values, this means mouselook can now be simulated with SimulatedInput for NPC Agents.