### PR TITLE
`SimulatedInput`: Analog Inputs No Longer Persist

### DIFF
--- a/net.bobbo.entity-input/simulated_input.gd
+++ b/net.bobbo.entity-input/simulated_input.gd
@@ -77,6 +77,9 @@ func gather_inputs(tick: EntityInput.TickType) -> void:
 	for action_name in _current_analog_by_tick_type[tick].keys():
 		var value = _current_analog_by_tick_type[tick][action_name]
 		_register_analog_input(action_name, value)
+	# ...then clean up the analog values. These should not persist between
+	# ticks.
+	_current_analog_by_tick_type[tick].clear()
 
 
 #


### PR DESCRIPTION
Analog inputs simulated using the SimulatedInput node no longer persist between ticks. This has been done to make coding the NPC system easier. IMO, it makes more sense to assume that not calling simulate_analog results in no analog input getting simulated, which was not true before if simulate_analog was called on a previous frame.