### PR TITLE
Convert KnowledgeDB from Autoload to a REAL SINGLETON

### DIFF
--- a/net.bobbo.knowledge/autoload/knowledge_db.tscn
+++ b/net.bobbo.knowledge/autoload/knowledge_db.tscn
@@ -1,6 +1,0 @@
-[gd_scene load_steps=2 format=3 uid="uid://qe6qs4j7coeb"]
-
-[ext_resource type="Script" path="res://addons/netengine5/net.bobbo.knowledge/autoload/knowledge_database.gd" id="1_4bb5k"]
-
-[node name="KnowledgeDB" type="Node"]
-script = ExtResource("1_4bb5k")

--- a/net.bobbo.knowledge/knowledge_db.gd
+++ b/net.bobbo.knowledge/knowledge_db.gd
@@ -111,7 +111,8 @@ static func _set_value(knowledge: Knowledge, new_value):
 	var is_new = knowledge in _knowledge_data.keys()
 
 	_knowledge_data[knowledge] = new_value
-	key_added.emit(knowledge)
+	if is_new:
+		key_added.emit(knowledge)
 
 	# Call the dynamic signal if relevant
 	var signal_key = _get_value_updated_signal_key(knowledge)

--- a/net.bobbo.knowledge/knowledge_db.gd
+++ b/net.bobbo.knowledge/knowledge_db.gd
@@ -23,6 +23,11 @@ static var key_removed: Signal:
 	get:
 		return _singleton.private_key_removed
 
+## By extending RefCounted and creating a new instance of ourselves in a static
+## variable, we can emulate a real singleton structure. This is better than
+## using an autoload because we don't need access to the SceneTree and the
+## singleton can exist without the user needing to enable the plugin, reducing
+## parse errors.
 static var _singleton := KnowledgeDB.new()
 static var _knowledge_data: Dictionary = {}  # Knowledge Resource -> Value
 

--- a/net.bobbo.knowledge/knowledge_db.gd
+++ b/net.bobbo.knowledge/knowledge_db.gd
@@ -108,7 +108,7 @@ static func load_state(path: String) -> bool:
 
 
 static func _set_value(knowledge: Knowledge, new_value):
-	var is_new = knowledge in _knowledge_data.keys()
+	var is_new := knowledge in _knowledge_data.keys()
 
 	_knowledge_data[knowledge] = new_value
 	if is_new:

--- a/net.bobbo.knowledge/knowledge_dock/knowledge_dock_tree.gd
+++ b/net.bobbo.knowledge/knowledge_dock/knowledge_dock_tree.gd
@@ -6,11 +6,13 @@ extends Tree
 
 
 func _enter_tree():
-	KnowledgeDB.amount_updated.connect(_update_tree.bind())
+	KnowledgeDB.key_added.connect(_update_tree.bind())
+	KnowledgeDB.key_removed.connect(_update_tree.bind())
 
 
 func _exit_tree():
-	KnowledgeDB.amount_updated.disconnect(_update_tree.bind())
+	KnowledgeDB.key_removed.disconnect(_update_tree.bind())
+	KnowledgeDB.key_added.disconnect(_update_tree.bind())
 
 
 #

--- a/net.bobbo.knowledge/knowledge_dock/knowledge_dock_tree.gd
+++ b/net.bobbo.knowledge/knowledge_dock/knowledge_dock_tree.gd
@@ -6,13 +6,13 @@ extends Tree
 
 
 func _enter_tree():
-	KnowledgeDB.key_added.connect(_update_tree.bind())
-	KnowledgeDB.key_removed.connect(_update_tree.bind())
+	KnowledgeDB.key_added.connect(_on_knowledge_key_added.bind())
+	KnowledgeDB.key_removed.connect(_on_knowledge_key_removed.bind())
 
 
 func _exit_tree():
-	KnowledgeDB.key_removed.disconnect(_update_tree.bind())
-	KnowledgeDB.key_added.disconnect(_update_tree.bind())
+	KnowledgeDB.key_removed.disconnect(_on_knowledge_key_removed.bind())
+	KnowledgeDB.key_added.disconnect(_on_knowledge_key_added.bind())
 
 
 #
@@ -79,3 +79,11 @@ func _create_tree_branch(
 
 		new_node.set_text(0, end_of_path)
 		parent_node = new_node
+
+
+func _on_knowledge_key_removed(_knowledge):
+	_update_tree()
+
+
+func _on_knowledge_key_added(_knowledge):
+	_update_tree()

--- a/net.bobbo.knowledge/plugin.gd
+++ b/net.bobbo.knowledge/plugin.gd
@@ -5,9 +5,6 @@ const KNOWLEDGE_ICON: Texture2D = preload("icons/knowledge_icon.png")
 
 
 func _enter_tree():
-	# Add the autoload
-	add_autoload_singleton("KnowledgeDB", "autoload/knowledge_db.tscn")
-
 	add_custom_type(
 		"KnowledgeAgent", "Node", preload("knowledge_agent.gd"), KNOWLEDGE_ICON
 	)
@@ -57,6 +54,3 @@ func _exit_tree():
 	remove_custom_type("KnowledgeInteger")
 	remove_custom_type("KnowledgeOperatorCondition")
 	remove_custom_type("KnowledgeString")
-
-	# Remove the autoload
-	remove_autoload_singleton("KnowledgeDB")


### PR DESCRIPTION
Refactors KnowledgeDB to function as a real singleton, rather than an autoload. This has been done to solve some nasty parse errors and overall make plugin setup smoother.