### PR TITLE
`GraphNodeDB` Descriptors Configuriable in ProjectSettings

### DIFF
--- a/net.bobbo.dialog-graph/dialog_graph_project_settings.gd
+++ b/net.bobbo.dialog-graph/dialog_graph_project_settings.gd
@@ -1,0 +1,51 @@
+@tool
+## A static class intended to assist with ProjectSettings for this plugin.
+class_name DialogGraphProjectSettings
+extends RefCounted
+
+#
+#   Constants
+#
+
+const DESCRIPTORS_SETTINGS_KEY := "netengine5/dialog_graph/descriptors"
+
+const DEFAULT_DESCRIPTORS := [
+	preload("nodes/entry/entry_desc.tres"),
+	preload("nodes/dialog_text/dialog_text_desc.tres"),
+	preload("nodes/choice_prompt/choice_prompt_desc.tres"),
+	preload("nodes/forwarder/forwarder_desc.tres"),
+]
+
+#
+#   Static Functions
+#
+
+
+static func internal_setup() -> void:
+	# Setup the DialogGraphNodeDescriptor field
+	ProjectSettings.add_property_info(
+		{
+			name = DESCRIPTORS_SETTINGS_KEY,
+			type = TYPE_ARRAY,
+			hint = PROPERTY_HINT_RESOURCE_TYPE,
+			hint_string = "DialogGraphNodeDescriptor"
+		}
+	)
+	ProjectSettings.set_as_basic(DESCRIPTORS_SETTINGS_KEY, true)
+	ProjectSettings.set_as_internal(DESCRIPTORS_SETTINGS_KEY, false)
+	ProjectSettings.set_initial_value(
+		DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
+	)
+
+	# Save our changes
+	ProjectSettings.save()
+
+
+static func get_descriptors() -> Array:
+	return ProjectSettings.get_setting(
+		DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
+	)
+
+
+static func set_descriptors(new_descriptors: Array) -> void:
+	ProjectSettings.set_setting(DESCRIPTORS_SETTINGS_KEY, new_descriptors)

--- a/net.bobbo.dialog-graph/dialog_graph_project_settings.gd
+++ b/net.bobbo.dialog-graph/dialog_graph_project_settings.gd
@@ -27,8 +27,12 @@ static func internal_setup() -> void:
 		{
 			name = DESCRIPTORS_SETTINGS_KEY,
 			type = TYPE_ARRAY,
-			hint = PROPERTY_HINT_RESOURCE_TYPE,
-			hint_string = "DialogGraphNodeDescriptor"
+			hint = PROPERTY_HINT_TYPE_STRING,
+			hint_string =
+			(
+				"%d/%d:DialogGraphNodeDescriptor"
+				% [TYPE_OBJECT, PROPERTY_HINT_RESOURCE_TYPE]
+			)
 		}
 	)
 	ProjectSettings.set_as_basic(DESCRIPTORS_SETTINGS_KEY, true)
@@ -36,6 +40,7 @@ static func internal_setup() -> void:
 	ProjectSettings.set_initial_value(
 		DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
 	)
+	ProjectSettings.set_setting(DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS)
 
 	# Save our changes
 	ProjectSettings.save()

--- a/net.bobbo.dialog-graph/dialog_graph_project_settings.gd
+++ b/net.bobbo.dialog-graph/dialog_graph_project_settings.gd
@@ -7,8 +7,11 @@ extends RefCounted
 #   Constants
 #
 
+## The ProjectSettings key of the DialogGraphNodeDescriptor Array for
+## GraphNodeDB to use.
 const DESCRIPTORS_SETTINGS_KEY := "netengine5/dialog_graph/descriptors"
 
+## The default value of the setting at DESCRIPTORS_SETTINGS_KEY
 const DEFAULT_DESCRIPTORS := [
 	preload("nodes/entry/entry_desc.tres").resource_path,
 	preload("nodes/dialog_text/dialog_text_desc.tres").resource_path,
@@ -17,12 +20,47 @@ const DEFAULT_DESCRIPTORS := [
 ]
 
 #
-#   Static Functions
+#   Public Functions
 #
 
 
+## Setup `net.bobbo.dialog-graph`'s ProjectSettings. Intended to only be called
+## internally by this plugin.
 static func internal_setup() -> void:
-	# Setup the DialogGraphNodeDescriptor field
+	_setup_descriptors_property()
+	ProjectSettings.save()
+
+
+## Get the DialogGraphNodeDescriptors identified in ProjectSettings.
+static func get_descriptors() -> Array[DialogGraphNodeDescriptor]:
+	var descriptor_paths: Array = ProjectSettings.get_setting(
+		DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
+	)
+
+	# Load all DialogGraphNodeDescriptors from our settings
+	var results: Array[DialogGraphNodeDescriptor] = []
+	for path in descriptor_paths:
+		# Sometimes a path can be an empty string - skip if that's the case.
+		if not path:
+			continue
+
+		# Load the resource at the given path, and add it to our results if the
+		# resource is actually a DialogGraphNodeDescriptor
+		var loaded_resource = load(path)
+		if loaded_resource is DialogGraphNodeDescriptor:
+			results.append(loaded_resource)
+	return results
+
+
+#
+#	Private Functions
+#
+
+
+## Setup the settings for DESCRIPTORS_SETTINGS_KEY in ProjectSettings. This
+## will ensure that the property is displayed correctly in the GUI, and ensure
+## that a default value is set correctly.
+static func _setup_descriptors_property() -> void:
 	ProjectSettings.add_property_info(
 		{
 			name = DESCRIPTORS_SETTINGS_KEY,
@@ -41,24 +79,3 @@ static func internal_setup() -> void:
 		ProjectSettings.set_setting(
 			DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
 		)
-
-	# Save our changes
-	ProjectSettings.save()
-
-
-static func get_descriptors() -> Array[DialogGraphNodeDescriptor]:
-	var descriptor_paths: Array = ProjectSettings.get_setting(
-		DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
-	)
-
-	# Load all DialogGraphNodeDescriptors from our settings
-	var descriptors: Array[DialogGraphNodeDescriptor] = []
-	for path in descriptor_paths:
-		if not path:
-			continue
-
-		var loaded_resource = load(path)
-		if loaded_resource is DialogGraphNodeDescriptor:
-			descriptors.append(loaded_resource)
-
-	return descriptors

--- a/net.bobbo.dialog-graph/dialog_graph_project_settings.gd
+++ b/net.bobbo.dialog-graph/dialog_graph_project_settings.gd
@@ -10,10 +10,10 @@ extends RefCounted
 const DESCRIPTORS_SETTINGS_KEY := "netengine5/dialog_graph/descriptors"
 
 const DEFAULT_DESCRIPTORS := [
-	preload("nodes/entry/entry_desc.tres"),
-	preload("nodes/dialog_text/dialog_text_desc.tres"),
-	preload("nodes/choice_prompt/choice_prompt_desc.tres"),
-	preload("nodes/forwarder/forwarder_desc.tres"),
+	preload("nodes/entry/entry_desc.tres").resource_path,
+	preload("nodes/dialog_text/dialog_text_desc.tres").resource_path,
+	preload("nodes/choice_prompt/choice_prompt_desc.tres").resource_path,
+	preload("nodes/forwarder/forwarder_desc.tres").resource_path,
 ]
 
 #
@@ -28,11 +28,7 @@ static func internal_setup() -> void:
 			name = DESCRIPTORS_SETTINGS_KEY,
 			type = TYPE_ARRAY,
 			hint = PROPERTY_HINT_TYPE_STRING,
-			hint_string =
-			(
-				"%d/%d:DialogGraphNodeDescriptor"
-				% [TYPE_OBJECT, PROPERTY_HINT_RESOURCE_TYPE]
-			)
+			hint_string = "%d/%d:*.tres" % [TYPE_STRING, PROPERTY_HINT_FILE]
 		}
 	)
 	ProjectSettings.set_as_basic(DESCRIPTORS_SETTINGS_KEY, true)
@@ -40,17 +36,29 @@ static func internal_setup() -> void:
 	ProjectSettings.set_initial_value(
 		DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
 	)
-	ProjectSettings.set_setting(DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS)
+
+	if not ProjectSettings.has_setting(DESCRIPTORS_SETTINGS_KEY):
+		ProjectSettings.set_setting(
+			DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
+		)
 
 	# Save our changes
 	ProjectSettings.save()
 
 
-static func get_descriptors() -> Array:
-	return ProjectSettings.get_setting(
+static func get_descriptors() -> Array[DialogGraphNodeDescriptor]:
+	var descriptor_paths: Array = ProjectSettings.get_setting(
 		DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
 	)
 
+	# Load all DialogGraphNodeDescriptors from our settings
+	var descriptors: Array[DialogGraphNodeDescriptor] = []
+	for path in descriptor_paths:
+		if not path:
+			continue
 
-static func set_descriptors(new_descriptors: Array) -> void:
-	ProjectSettings.set_setting(DESCRIPTORS_SETTINGS_KEY, new_descriptors)
+		var loaded_resource = load(path)
+		if loaded_resource is DialogGraphNodeDescriptor:
+			descriptors.append(loaded_resource)
+
+	return descriptors

--- a/net.bobbo.dialog-graph/graph_node_db.gd
+++ b/net.bobbo.dialog-graph/graph_node_db.gd
@@ -8,12 +8,7 @@ extends RefCounted
 #	Private Variables
 #
 
-var _descriptors: Array[DialogGraphNodeDescriptor] = [
-	preload("nodes/entry/entry_desc.tres"),
-	preload("nodes/dialog_text/dialog_text_desc.tres"),
-	preload("nodes/choice_prompt/choice_prompt_desc.tres"),
-	preload("nodes/forwarder/forwarder_desc.tres"),
-]
+var _descriptors: Array[DialogGraphNodeDescriptor]
 
 #
 #	Static Variables
@@ -34,7 +29,19 @@ static var descriptors: Array[DialogGraphNodeDescriptor]:
 		return _singleton._descriptors
 
 #
-#	Public Funcitons
+#	Godot Functions
+#
+
+
+func _init():
+	# Read the descriptors from the project settings
+	var found_descriptors = DialogGraphProjectSettings.get_descriptors()
+	_descriptors = []
+	_descriptors.assign(found_descriptors)
+
+
+#
+#	Static Funcitons
 #
 
 

--- a/net.bobbo.dialog-graph/graph_node_db.gd
+++ b/net.bobbo.dialog-graph/graph_node_db.gd
@@ -22,8 +22,6 @@ var _descriptors: Array[DialogGraphNodeDescriptor]
 static var _singleton := GraphNodeDB.new()
 
 ## A list of descriptors that represent what kind of dialog nodes exist.
-## TODO - convert to maybe DialogGraphNodeDescriptor adding itself via a static
-## constructor?
 static var descriptors: Array[DialogGraphNodeDescriptor]:
 	get:
 		return _singleton._descriptors
@@ -35,9 +33,7 @@ static var descriptors: Array[DialogGraphNodeDescriptor]:
 
 func _init():
 	# Read the descriptors from the project settings
-	var found_descriptors = DialogGraphProjectSettings.get_descriptors()
-	_descriptors = []
-	_descriptors.assign(found_descriptors)
+	_descriptors = DialogGraphProjectSettings.get_descriptors()
 
 
 #

--- a/net.bobbo.dialog-graph/plugin.gd
+++ b/net.bobbo.dialog-graph/plugin.gd
@@ -110,6 +110,9 @@ func _enter_tree():
 		DIALOG_RUNNER_STATE_ICON
 	)
 
+	# Setup the project settings
+	DialogGraphProjectSettings.internal_setup()
+
 	# Spawn the graph editor
 	_graph_editor_instance = GRAPH_EDITOR_SCENE.instantiate()
 	get_editor_interface().get_editor_main_screen().add_child(


### PR DESCRIPTION
Revises the `net.bobbo.dialog-graph` implementation to refer to ProjectSettings when determining what DialogGraphNodeDescriptors exist.

This allows projects to provide custom DialogGraphNodeDescriptors.