### PR TITLE
BUGFIX: Resolve PropertySettings assert failutre on project start

### DIFF
--- a/net.bobbo.dialog-graph/dialog_graph_project_settings.gd
+++ b/net.bobbo.dialog-graph/dialog_graph_project_settings.gd
@@ -61,6 +61,11 @@ static func get_descriptors() -> Array[DialogGraphNodeDescriptor]:
 ## will ensure that the property is displayed correctly in the GUI, and ensure
 ## that a default value is set correctly.
 static func _setup_descriptors_property() -> void:
+	if not ProjectSettings.has_setting(DESCRIPTORS_SETTINGS_KEY):
+		ProjectSettings.set_setting(
+			DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
+		)
+
 	ProjectSettings.add_property_info(
 		{
 			name = DESCRIPTORS_SETTINGS_KEY,
@@ -74,8 +79,3 @@ static func _setup_descriptors_property() -> void:
 	ProjectSettings.set_initial_value(
 		DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
 	)
-
-	if not ProjectSettings.has_setting(DESCRIPTORS_SETTINGS_KEY):
-		ProjectSettings.set_setting(
-			DESCRIPTORS_SETTINGS_KEY, DEFAULT_DESCRIPTORS
-		)


### PR DESCRIPTION
Fixes a bug where [this assert](https://github.com/godotengine/godot/blob/568589c9d8c763bfb3a4348174d53b42d7c59f21/core/config/project_settings.cpp#L1138) would fail upon opening the project. This is because `ProjectSettings.add_property_info` in `net.bobbo.dialog-graph` was placed BEFORE the ProjectSettings property was potentially assigned.